### PR TITLE
Update index.js extends order for for correct rule application

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
+    './es6.js',
     './best-practices.js',
     './stylistic.js',
     './possible-errors.js',
     './variables.js',
-    './es6.js',
   ],
   rules: {}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-policygenius",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "This package provides Policygenius' .eslintrc as an extensible shared config",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
- Moves `es6` extension to the top of the `index.js` extends array. It was initially the last extension but it caused some linting rules from the extensions above to not be applied.