### PR TITLE
update quotes and react/jsx-curly-brace-presence rules

### DIFF
--- a/react.js
+++ b/react.js
@@ -117,8 +117,7 @@ module.exports = {
     'react/jsx-no-undef': 'error',
     'react/jsx-curly-brace-presence': [
       'error', {
-        props: "never",
-        children: "never"
+        props: "never"
       }
     ],
     'react/jsx-pascal-case': 'error',

--- a/stylistic.js
+++ b/stylistic.js
@@ -118,7 +118,9 @@ module.exports = {
       { blankLine: "always", prev: "*", next: "return" }
     ],
     quotes: [
-      "error",   "single"
+      "error",
+      "single",
+      { "avoidEscape": true }
     ],
     "semi-spacing": "error",
     "semi-style": [


### PR DESCRIPTION
Update eslint rules that were discovered to be unnecessary/too restrictive while upgrading `athenaeum`

- `react/jsx-curly-brace-presence` - keep error for unnecessary curly braces for `props` but remove rule for `children`
- `quotes` - add `avoidEscape: true` so double-quotes can be used to avoid having to escape single quotes