### PR TITLE
Update space-before-function-paren for async functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-policygenius",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "This package provides Policygenius' .eslintrc as an extensible shared config",
   "main": "index.js",
   "license": "MIT",

--- a/stylistic.js
+++ b/stylistic.js
@@ -128,7 +128,11 @@ module.exports = {
     ],
     "space-before-blocks": "error",
     "space-before-function-paren": [
-      "error", "never"
+      "error", {
+        "anonymous": "never",
+        "named": "never",
+        "asyncArrow": "always"
+      }
     ],
     "space-in-parens": [
       "error", "never"


### PR DESCRIPTION
@policygenius/bago-bunch CR please

- Updates the config to allow for `async` functions to have a space before the opening paren.

Before
```js
async() => {} // good

async () => {} // error
```

After: 
```js
async () => {} // good

async() => {} // error
```