### PR TITLE
Add pipeline for publishing to NPM

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,46 @@
+---
+steps:
+  - name: ':docker: Build'
+    branches: main
+    agents:
+      queue: builder
+    plugins:
+      docker-compose:
+        build: eslint-config-policygenius
+        image-repository: us.gcr.io/pg-shared-v1/eslint-config-policygenius
+        image-name: $BUILDKITE_BUILD_NUMBER
+
+  - wait
+
+  - block: 'Trigger deploy/publish'
+    branches: main
+    prompt: 'Choose a version bump'
+    fields:
+      - select: 'Increment'
+        key: 'bump-size'
+        hint: "MAJOR: backwards-incompatible API changes // MINOR: add backwards-compatible functionality // PATCH: backwards-compatible bug fixes"
+        required: true
+        options:
+          - label: 'Major'
+            value: 'major'
+          - label: 'Minor'
+            value: 'minor'
+          - label: 'Patch'
+            value: 'patch'
+
+  - name: ':npm: Bump and Publish version'
+    branches: main
+    command: bin/bump_and_publish_version
+    agents:
+      queue: builder
+    plugins:
+      docker-compose:
+        run: eslint-config-policygenius
+
+  - wait
+
+  - name: ':octocat: Tag new version'
+    branches: main
+    command: bin/tag_version
+    agents:
+      queue: builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:14.3
+
+COPY package.json /app/
+COPY yarn.lock /app/
+
+WORKDIR /app
+
+RUN yarn --frozen-lockfile
+
+COPY . /app/

--- a/bin/bump_and_publish_version
+++ b/bin/bump_and_publish_version
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eo pipefail
+
+BUMP_SIZE=$(buildkite-agent meta-data get bump-size)
+
+# npm version will update the local package.json in-place with the next version number
+echo '+++ Getting next NPM version from npm'
+VERSION=$(npm --no-git-tag-version version $BUMP_SIZE)
+echo "+++ Next version: $VERSION"
+
+echo '+++ Publishing the package'
+echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+
+npm whoami
+
+# npm publish will use the version number from the local package.json
+# which was set to the next version number by `npm version` above
+npm publish
+
+# Declare a `new-version` metadata value, to be used later in the tag_version script, along with the updated package.json artifact
+buildkite-agent meta-data set new-version $VERSION
+buildkite-agent artifact upload package.json
+buildkite-agent artifact upload yarn.lock

--- a/bin/tag_version
+++ b/bin/tag_version
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+git config --global user.name "Randy the PolicyGenius Robot"
+git config --global user.email "robot@policygenius.com"
+git config --global push.default simple
+
+git fetch
+git checkout $BUILDKITE_BRANCH
+git reset --hard origin/$BUILDKITE_BRANCH
+
+buildkite-agent artifact download package.json .
+buildkite-agent artifact download yarn.lock .
+VERSION=$(buildkite-agent meta-data get new-version)
+
+# -- Update Package.json
+echo "Adding updated package.json and tagging new git tag $VERSION"
+git add package.json
+git add yarn.lock
+git tag -a "$VERSION" -m "Publish version $VERSION"
+
+# -- 🚀 send it
+echo 'Committing updated package.json with version bump to main'
+git commit -m "Bump to $VERSION [ci skip]"
+git push --follow-tags origin $BUILDKITE_BRANCH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.2'
+services:
+  eslint-config-policygenius:
+    build: .
+    volumes:
+      - .:/go/src/github.com/buildkite/agent
+      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
+    environment:
+      - BUILDKITE
+      - BUILDKITE_COMMIT
+      - BUILDKITE_BRANCH
+      - BUILDKITE_PULL_REQUEST
+      - BUILDKITE_REPO
+      - BUILDKITE_BUILD_ID=$BUILDKITE_BUILD_ID
+      - BUILDKITE_AGENT_ACCESS_TOKEN=$BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_NUMBER
+      - NPM_USERNAME
+      - NPM_PASSWORD
+      - NPM_TOKEN
+      - NPM_EMAIL


### PR DESCRIPTION
Previously, if one wanted to publish eslint-config-policygenius, they
needed to do so from their local command line by signing in to the
Policygenius NPM account.

This commit moves this process to Buildkite where all merges to main
will allow an engineer to automatically publish that change to npm.