### PR TITLE
Upgrade Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14.17
 
 COPY package.json /app/
 COPY yarn.lock /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.3
+FROM node:14
 
 COPY package.json /app/
 COPY yarn.lock /app/


### PR DESCRIPTION
Node 14.3 was incompatible with `@typescript-eslint/eslint-plugin@5.10.2`
https://buildkite.com/policygenius/eslint-config-policygenius/builds/49#b0f26786-40ad-4032-bc91-7607856a8e41

Updates Node image to 14.17