### PR TITLE
Update jest.js

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -10,18 +10,18 @@ module.exports = {
       }
     ],
     'jest/expect-expect': 'error',
-    'jest/lowercase-name': [
+    'jest/no-disabled-tests': 'warn',
+    'jest/no-focused-tests': 'warn',
+    'jest/no-jasmine-globals': 'error',
+    'jest/no-test-prefixes': 'warn',
+    'jest/prefer-lowercase-title': [
       'error',
       {
         ignore: ['describe'],
       }
     ],
-    'jest/no-disabled-tests': 'warn',
-    'jest/no-focused-tests': 'warn',
-    'jest/no-jasmine-globals': 'error',
-    'jest/no-test-prefixes': 'warn',
     'jest/prefer-to-have-length': 'off',
-    'jest/valid-describe': 'error',
+    'jest/valid-describe-callback': 'error',
     'jest/valid-expect-in-promise': 'error',
   }
 }


### PR DESCRIPTION
While upgrading the mortar es-lint config, I got errors concerning two jest rules that were renamed in eslint-plugin-jest: 25.0.0:
1.  `jest/lowercase-name` >>> `jest/prefer-lowercase-title`
2. `jest/valid-describe` >>> `jest/valid-describe-callback`

This fixes that!

https://github.com/jest-community/eslint-plugin-jest/blob/main/CHANGELOG.md#breaking-changes-1