### PR TITLE
Upgrade docker version and switch to using pg sourced image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,6 @@
 ---
 steps:
   - name: ':docker: Build'
-    branches: main
     agents:
       queue: builder
     plugins:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17
+FROM us.gcr.io/pg-shared-v1/node16-18-alpine3-16:latest
 
 COPY package.json /app/
 COPY yarn.lock /app/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ Please be sure to have the following installed when using this config.
 - `eslint-plugin-prettier@4.0.0`
 
 ### If using Typescript
-- `node >=12.22.0`
+- `node >=16.18.0`
 - `@typescript-eslint/parser@^6.1.0`
 - `@typescript-eslint/eslint-plugin@^6.1.0`


### PR DESCRIPTION
## Description
This repo doesn't build unless you are on main apparently...  But the node version of the docker file needs to be bumped in order to build the typescript upgrades.
Also updates the build to always run so that we don't run into that issue again.